### PR TITLE
Ordenando projetos a partir do número de Stars no github

### DIFF
--- a/page-projects.php
+++ b/page-projects.php
@@ -36,6 +36,7 @@
                 $html .= '<h1 class="project-name"><a href="http://github.com/' . $onde[0] . '" title="' . get_the_title() . '">' . get_the_title() . '</a></h1>';
 
                 // Busca no github o número de stars para ordenar depois,
+                //$git_url = "https://api.github.com/repos/" . $onde[0] ;
                 $git_url = "https://api.github.com/repos/" . $onde[0] ;
                 $ch = curl_init( $git_url ) ;
                 curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
@@ -77,10 +78,12 @@
             endwhile; endif; wp_reset_query(); ?>
 
         <?php
-          usort( $projetos , function( $a, $b ) {
+          function ordenar_projetos( $a, $b ) {
             if( $a{"stars"} == $b{"stars"} ) { return 0; }
             return( $a{"stars"} > $b{"stars"} ) ? -1 : 1;
-          } );
+          }
+          usort( $projetos , "ordenar_projetos" );
+
           foreach( $projetos as $projeto ) {
             echo $projeto{"html"} ;
           }


### PR DESCRIPTION
Alterei a forma de exibir os projetos para que quando for feita a query seja verificado qual o número de Stars, conforme proposto pelo @felquis: https://github.com/braziljs/foundation/issues/84
