### PR TITLE
Event price transition updated

### DIFF
--- a/src/files/css/main.css
+++ b/src/files/css/main.css
@@ -1130,12 +1130,18 @@ label.error {
   font-size:14px;
   font-weight: bolder;
   border-radius: 4px 0 4px 0;
-  -webkit-transition: right 0.3s ease-out;
-  -moz-transition: right 0.3s ease-out;
-  -o-transition: right 0.3s ease-out;
-  transition: right 0.3s ease-out;
+  -webkit-transition: -webkit-transform 0.3s ease-out;
+  -moz-transition: -moz-transform 0.3s ease-out;
+  -o-transition: -o-transform 0.3s ease-out;
+  transition: transform 0.3s ease-out;
 }
-.event:hover .event-price  {right:58px;}
+.event:hover .event-price  {
+   -webkit-transform: translateX(-78px);
+   -moz-transform: translateX(-78px);
+   -ms-transform: translateX(-78px);
+   -o-transform: translateX(-78px);
+   transform: translateX(-78px);
+}
 .event-name {
   text-align: center;
   font-size: 25px;


### PR DESCRIPTION
I was taking a look at the events and I noticed that the price transition on hover were too sluggish, so I thought that it would be better to change the CSS to use transform translateX rather than to transition the right property on hover.
I tested and noticed that it got much faster in Chrome, but had almost no difference in FF and IE.

Paul Irish explains this performance issue here:
http://www.paulirish.com/2012/why-moving-elements-with-translate-is-better-than-posabs-topleft/
