### PR TITLE
Add Alagoas Dev Day price

### DIFF
--- a/src/files/services/events/2014.json
+++ b/src/files/services/events/2014.json
@@ -22,7 +22,7 @@
       "thumbnail": "http://braziljs.org/services/events/media/2014/alagoasdevday.jpg",
       "location": "Maceió, AL",
       "date": "2014-04-12",
-      "price": "R$ ??"
+      "price": "R$ 45"
     }
   ]
 }


### PR DESCRIPTION
According to the event's website, R$45 is the price for the first batch of tickets.
