### PR TITLE
Inseriando imagem (logotipo) temporária

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # BrazilJS.org
 
-![Cover](http://braziljs.org/img/projects/braziljsorg.jpg)
+<!-- imagem temporária -->
+![Cover](https://raw.githubusercontent.com/pedropolisenso/braziljs.org/master/src/files/img/projects/braziljsorg.jpg)
 
 A non-profit foundation with a mission to move and unify JavaScript community in Brazil.
 


### PR DESCRIPTION
Vi que na documentação a URL da imagem estava apontando para um diretório específico no site, porém vi que o site da organização estava com problemas e achei que seria legal colocar a imagem com uma URL temporária.
