### PR TITLE
Adiciona informações sobre o post Closes #161

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory": "src/files/packages/"
+}

--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,3 @@
 {
-  "directory": "src/files/packages/"
+  "directory": "src/files/vendor/"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,4 @@ out
 validation-status.json
 
 # Bower Packages
-src/files/packages/
+src/files/vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ out
 
 # Grunt HTML validation
 validation-status.json
+
+# Bower Packages
+src/files/packages/

--- a/authors.js
+++ b/authors.js
@@ -1,0 +1,16 @@
+module.exports = {
+  braziljs: {
+    name: "braziljs",
+    bio: "Uma fundação sem fins lucrativos com a missão de mover e unir a comunidade de JavaScript no Brasil.",
+    gravatar: "",
+    gplus: "",
+    twitter: "braziljs"
+  },
+  zeno_rocha: {
+    name: "Zeno Rocha",
+    bio: "",
+    gravatar: "",
+    gplus: "",
+    twitter: "zenorocha"
+  }
+}

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,24 @@
+{
+  "name": "braziljs.org",
+  "version": "0.0.0",
+  "homepage": "http://braziljs.org/",
+  "authors": [
+    "Randson Oliveira <randsonjs@gmail.com>"
+  ],
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/braziljs/braziljs.org.git"
+  },
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "src/files/vendor/",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "fontawesome": "~4.3.0"
+  }
+}

--- a/docpad.js
+++ b/docpad.js
@@ -3,12 +3,32 @@ module.exports = {
   // -- Basic information ----------------------------------------------------
   templateData: {
 
+    // Authors
+    authors: require("./authors"),
+
     // Production
     site: {
       name: "BrazilJS",
       description: "Uma fundação sem fins lucrativos com a missão de mover e unir a comunidade de JavaScript no Brasil.",
       url: "http://braziljs.org"
-    }
+    },
+
+    /* Helpers
+      ===================================================================== */
+    getAuthor: function(author) {
+      if(author)
+        return this.authors[author];
+
+      return this.authors["braziljs"];
+    },
+
+    getAuthorGooglePlus: function(author) {
+      return "https://plus.google.com/" + this.authors[author].gplus + "/";
+    },
+
+    getAuthorTwitter: function(author) {
+      return "https://twitter.com/" + this.authors[author].twitter;
+    },
 
   },
 

--- a/src/documents/blog/a-descentralizacao-de-conteudo-no-facebook.html.md
+++ b/src/documents/blog/a-descentralizacao-de-conteudo-no-facebook.html.md
@@ -2,6 +2,7 @@
 title: 'Uma sugestão para a descentralização de conteúdo nos Grupos do Facebook'
 date: '2012-10-09'
 layout: blog
+authors: [braziljs]
 old_url: http://braziljs.org/a-descentralizacao-de-conteudo-no-facebook/
 ---
 

--- a/src/documents/blog/anunciando-a-braziljs-foundation.html.md
+++ b/src/documents/blog/anunciando-a-braziljs-foundation.html.md
@@ -2,6 +2,7 @@
 title: 'Anunciando a BrazilJS Foundation'
 date: '2012-07-22'
 layout: blog
+authors: [braziljs]
 old_url: http://braziljs.org/anunciando-a-braziljs-foundation/
 ---
 

--- a/src/documents/blog/apresentando-conf-boilerplate.html.md
+++ b/src/documents/blog/apresentando-conf-boilerplate.html.md
@@ -2,6 +2,7 @@
 title: Apresentando o ConfBoilerplate
 date: '2012-11-20'
 layout: blog
+authors: [braziljs]
 old_url: http://braziljs.org/apresentando-conf-boilerplate/
 ---
 

--- a/src/documents/blog/braziljs-conf-2013-teaser-e-douglas-crockford.html.md
+++ b/src/documents/blog/braziljs-conf-2013-teaser-e-douglas-crockford.html.md
@@ -2,6 +2,7 @@
 title: 'BrazilJS Conf 2013: Teaser e Douglas Crockford'
 date: '2013-02-20'
 layout: blog
+authors: [braziljs]
 old_url: http://braziljs.org/braziljs-conf-2013-teaser-e-douglas-crockford/
 ---
 

--- a/src/documents/blog/epic-fail.html.md
+++ b/src/documents/blog/epic-fail.html.md
@@ -2,6 +2,7 @@
 title: Epic fail
 date: '2012-12-12'
 layout: blog
+authors: [braziljs]
 old_url: http://braziljs.org/epic-fail/
 ---
 

--- a/src/documents/blog/eureka.html.md
+++ b/src/documents/blog/eureka.html.md
@@ -2,6 +2,7 @@
 title: 'Eureka!'
 date: '2015-01-21'
 layout: blog
+authors: [zeno_rocha]
 ---
 
 Desde quando a gente começou com toda essa história de BrazilJS, várias ideias que tinham potencial para ajudar a comunidade foram aparecendo.

--- a/src/documents/blog/momento-braziljs-webbr.html.md
+++ b/src/documents/blog/momento-braziljs-webbr.html.md
@@ -2,6 +2,7 @@
 title: 'Momento BrazilJS na Web.br'
 date: '2012-10-02'
 layout: blog
+authors: [braziljs]
 old_url: http://braziljs.org/momento-braziljs-webbr/
 ---
 

--- a/src/layouts/blog.html.eco
+++ b/src/layouts/blog.html.eco
@@ -22,7 +22,7 @@ layout: default
   }
 </style>
 
-<link rel="stylesheet" href="/packages/fontawesome/css/font-awesome.min.css">
+<link rel="stylesheet" href="/vendor/fontawesome/css/font-awesome.min.css">
 
 <section class="content">
 

--- a/src/layouts/blog.html.eco
+++ b/src/layouts/blog.html.eco
@@ -6,7 +6,23 @@ layout: default
   .content-blog p {
     margin-bottom: 15px;
   }
+
+  .post-info {
+    text-transform: uppercase;
+    color: #999;
+    margin: -10px 0px 5px 0px;
+  }
+
+  .post-info span:first-child {
+    margin-left: 0;
+  }
+
+  .post-info span {
+    margin-left: 10px;
+  }
 </style>
+
+<link rel="stylesheet" href="/packages/fontawesome/css/font-awesome.min.css">
 
 <section class="content">
 
@@ -15,6 +31,21 @@ layout: default
     <article class="content-blog">
 
       <h2 style="text-align: left;"><%= @document.title %></h2>
+
+      <div class="post-info" role="complementary">
+        <span class="post-author">
+          <% for author, i in @document.authors: %>
+            <% if i == 0: %>Por<% else: %>&<% end %>
+            <a href="<%= @getAuthorTwitter(author) %>" target="_blank"><%= @getAuthor(author).name %></a>
+          <% end %>
+        </span>
+
+        <span class="post-date">
+          <i class="fa fa-clock-o"></i>
+          <%= @moment(@document.date).format('DD/MM/YYYY') %>
+        </span>
+      </div>
+
       <%- @content %>
 
       <div id="disqus_thread"></div>


### PR DESCRIPTION
Adicionei as informações como Usuário e Data do post.

Coloquei um ícone do font-awesome na data e uma instalação pelo bower. Alterei também a pasta padrão de instalação do bower e adicionei ela no `.gitignore`.

Também peguei o modelo de autores do Web Components. Assim cada autor poderá ter sua descrição, twitter, GPlus e tals.

No mais, acho que isso :tada: 

cc/ @zenorocha 