### PR TITLE
Update docpad and dependencies enabling support for the stable Node v4 version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 
 node_js:
-- '0.10'
+- '4.1'

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
   "private": true,
   "engines": {
-    "node": "0.10",
+    "node": "4.0",
     "npm": "2.0"
   },
   "dependencies": {
-    "docpad": "^6.69.2",
-    "docpad-plugin-cleanurls": "^2.7.0",
-    "docpad-plugin-eco": "^2.1.0",
-    "docpad-plugin-ghpages": "^2.4.0",
-    "docpad-plugin-marked": "^2.2.1",
-    "docpad-plugin-moment": "^2.0.2"
+    "docpad": "~6.78.4",
+    "docpad-plugin-cleanurls": "~2.8.1",
+    "docpad-plugin-eco": "~2.1.0",
+    "docpad-plugin-ghpages": "~2.4.4",
+    "docpad-plugin-marked": "~2.3.0",
+    "docpad-plugin-moment": "~2.0.2"
   },
   "devDependencies": {
     "grunt": "~0.4.2",


### PR DESCRIPTION
Hello guys.

I bumped the `docpad`, it's plugins and the `node` version so that more people can contribute. Many people are using `node` v4+ now that it achieved the stable status.

Also changed the carret prefix for the tilde one as there is less chance to break if the plugins don't follow [semver](http://semver.org/).